### PR TITLE
Fixes a test failure in batch_test.go.

### DIFF
--- a/serve/model/schema/schema.go
+++ b/serve/model/schema/schema.go
@@ -19,10 +19,6 @@ func Create(db *db.DB, name string) (err error) {
 		fmt.Sprintf("CREATE TABLE %s.TodoList (Id INT PRIMARY KEY NOT NULL, OwnerUserId INT NOT NULL, FOREIGN KEY (OwnerUserId) REFERENCES %s.User (Id))", name, name),
 		fmt.Sprintf("CREATE TABLE %s.Todo (Id INT PRIMARY KEY NOT NULL, TodoListId INT NOT NULL, Title VARCHAR(255) NOT NULL, Complete BIT NOT NULL, SortOrder FLOAT(53) NOT NULL, FOREIGN KEY (TodoListId) REFERENCES %s.TodoList (Id))", name, name),
 		fmt.Sprintf("CREATE TABLE %s.Replicache (ClientID VARCHAR(255) PRIMARY KEY NOT NULL, MutationID INT NOT NULL)", name),
-
-		// These initial rows are required by the Flutter quickstart to be present.
-		fmt.Sprintf("INSERT INTO %s.User (Email) VALUES ('test@test.com')", name),
-		fmt.Sprintf("INSERT INTO %s.TodoList (Id, OwnerUserId) VALUES (1, 1)", name),
 	}
 
 	schemaHash := sha1.Sum([]byte(strings.Join(statements, "\n")))

--- a/serve/model/schema/schema_test.go
+++ b/serve/model/schema/schema_test.go
@@ -16,11 +16,7 @@ func TestSchema(t *testing.T) {
 	out, err := db.ExecStatement("SHOW DATABASES LIKE 'foo'", nil)
 	assert.Equal(1, len(out.Records))
 	out, err = db.ExecStatement("SELECT Id, Email FROM foo.User", nil)
-	assert.Equal(1, len(out.Records))
-	assert.Equal(int64(1), *(*out.Records[0][0]).LongValue)
-	assert.Equal("test@test.com", *(*out.Records[0][1]).StringValue)
+	assert.Equal(0, len(out.Records))
 	out, err = db.ExecStatement("SELECT Id, OwnerUserId FROM foo.TodoList", nil)
-	assert.Equal(1, len(out.Records))
-	assert.Equal(int64(1), *(*out.Records[0][0]).LongValue)
-	assert.Equal(int64(1), *(*out.Records[0][1]).LongValue)
+	assert.Equal(0, len(out.Records))
 }


### PR DESCRIPTION
It seems this must have been broken for awhile?

This assert: https://github.com/rocicorp/replicache-sample-todo/blob/master/serve/handlers/batch/batch_test.go#L39 fails because list creation fails because the schema creation already puts a record in with that value. Weird.